### PR TITLE
apply most clippy suggestions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -164,7 +164,7 @@ impl Error {
             e.profile = e.tag.profile()
                 .or_else(|| Some(config.profile().clone()));
 
-            error = e.prev.as_mut().map(|v| &mut **v);
+            error = e.prev.as_deref_mut();
         }
 
         self
@@ -183,10 +183,7 @@ impl Error {
     /// assert!(error.missing());
     /// ```
     pub fn missing(&self) -> bool {
-        match self.kind {
-            Kind::MissingField(..) => true,
-            _ => false
-        }
+        matches!(self.kind, Kind::MissingField(..))
     }
 
     /// Append the string `path` to the error's path.

--- a/src/jail.rs
+++ b/src/jail.rs
@@ -144,7 +144,7 @@ impl Jail {
     pub fn create_file<P: AsRef<Path>>(&self, path: P, contents: &str) -> Result<File> {
         let path = path.as_ref();
         if !path.is_relative() {
-            Err("Jail::create_file(): file path is absolute".to_string())?;
+            return Err("Jail::create_file(): file path is absolute".to_string().into());
         }
 
         let file = File::create(self.directory().join(path)).map_err(as_string)?;
@@ -180,7 +180,7 @@ impl Jail {
 
 impl Drop for Jail {
     fn drop(&mut self) {
-        self.env_vars.iter().for_each(|k| std::env::remove_var(k));
+        self.env_vars.iter().for_each(std::env::remove_var);
         let _ = std::env::set_current_dir(&self.old_cwd);
     }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -48,12 +48,10 @@ impl From<ProfileTag> for Option<Profile> {
 
 impl From<&Profile> for ProfileTag {
     fn from(profile: &Profile) -> Self {
-        if profile == &Profile::Default {
-            ProfileTag::Default
-        } else if profile == &Profile::Global {
-            ProfileTag::Global
-        } else {
-            ProfileTag::Custom
+        match profile {
+            p if p == Profile::Default => ProfileTag::Default,
+            p if p == Profile::Global => ProfileTag::Global,
+            _ => ProfileTag::Custom
         }
     }
 }
@@ -194,7 +192,7 @@ impl Profile {
     /// assert!(!Profile::Global.is_custom());
     /// ```
     pub fn is_custom(&self) -> bool {
-        self != &Profile::Default && self != &Profile::Global
+        self != Profile::Default && self != Profile::Global
     }
 
     /// Creates a new map with a single key of `*self` and a value of `dict`.

--- a/src/providers/data.rs
+++ b/src/providers/data.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::io::{Read, BufReader};
 use std::path::{Path, PathBuf};
 
 use serde::de::{self, DeserializeOwned};
@@ -300,12 +299,7 @@ pub trait Format: Sized {
     /// an error if the `string` is an invalid `T`. The default implementation
     /// calls [`Format::from_str()`] with the contents of the file.
     fn from_path<T: DeserializeOwned>(path: &Path) -> Result<T, Self::Error> {
-        let mut source = String::new();
-        std::fs::File::open(path)
-            .map(|file| BufReader::new(file))
-            .and_then(|mut reader| reader.read_to_string(&mut source))
-            .map_err(|e| de::Error::custom(e))?;
-
+        let source = std::fs::read_to_string(path).map_err(de::Error::custom)?;
         Self::from_str(&source)
     }
 

--- a/src/providers/env.rs
+++ b/src/providers/env.rs
@@ -296,7 +296,7 @@ impl Env {
     /// });
     /// ```
     pub fn ignore(self, keys: &[&str]) -> Self {
-        let keys: Vec<String> = keys.iter().map(|s| s.to_string().into()).collect();
+        let keys: Vec<String> = keys.iter().map(|s| s.to_string()).collect();
         self.filter(move |key| !keys.iter().any(|k| k.as_str() == key))
     }
 
@@ -325,7 +325,7 @@ impl Env {
     /// });
     /// ```
     pub fn only(self, keys: &[&str]) -> Self {
-        let keys: Vec<String> = keys.iter().map(|s| s.to_string().into()).collect();
+        let keys: Vec<String> = keys.iter().map(|s| s.to_string()).collect();
         self.filter(move |key| keys.iter().any(|k| k.as_str() == key))
     }
 
@@ -452,7 +452,7 @@ impl Provider for Env {
                     .map(|k| k.to_ascii_uppercase())
                     .collect();
 
-                format!("{}", keys.join("."))
+                keys.join(".")
             });
 
         if let Some(prefix) = &self.prefix {

--- a/src/util.rs
+++ b/src/util.rs
@@ -98,7 +98,7 @@ pub fn diff_paths<P, B>(path: P, base: B) -> Option<PathBuf>
         }
     }
 
-    Some(comps.iter().map(|c| c.as_os_str()).collect::<PathBuf>().into())
+    Some(comps.iter().map(|c| c.as_os_str()).collect())
 }
 
 /// A helper to deserialize `0/false` as `false` and `1/true` as `true`.

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -350,7 +350,7 @@ struct RawValue(Value);
 
 impl<'de> Deserialize<'de> for RawValue {
     fn deserialize<D: Deserializer<'de>>(de: D) -> result::Result<Self, D::Error> {
-        de.deserialize_any(ValueVisitor).map(|v| RawValue(v))
+        de.deserialize_any(ValueVisitor).map(RawValue)
     }
 }
 
@@ -434,7 +434,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
 
         if let Some(mut value) = raw_val {
             if let Some(id) = id {
-                value.0.map_tag(|t| *t = Tag::from(id));
+                value.0.map_tag(|t| *t = id);
             }
 
             return Ok(value.0);

--- a/src/value/magic.rs
+++ b/src/value/magic.rs
@@ -135,7 +135,7 @@ impl Magic for RelativePathBuf {
         }
 
         // If we have this struct with no metadata_path, still use the value.
-        let value = de.value.find_ref(Self::FIELDS[1]).unwrap_or_else(|| &de.value);
+        let value = de.value.find_ref(Self::FIELDS[1]).unwrap_or(&de.value);
         map.insert(Self::FIELDS[1].into(), value.clone());
         visitor.visit_map(MapDe::new(&map, |v| ConfiguredValueDe::from(config, v)))
     }
@@ -448,7 +448,7 @@ impl<T: for<'de> Deserialize<'de>> Magic for Tagged<T> {
         }
 
         // If we have this struct with default tag, use the value.
-        let value = de.value.find_ref(Self::FIELDS[1]).unwrap_or_else(|| &de.value);
+        let value = de.value.find_ref(Self::FIELDS[1]).unwrap_or(&de.value);
         map.insert(Self::FIELDS[0].into(), de.value.tag().into());
         map.insert(Self::FIELDS[1].into(), value.clone());
         visitor.visit_map(MapDe::new(&map, |v| ConfiguredValueDe::from(config, v)))
@@ -810,7 +810,7 @@ mod _serde {
                         })
                     }
                 }
-                const FIELDS: &'static [&'static str] = &[
+                const FIELDS: &[&str] = &[
                     "___figment_relative_metadata_path",
                     "___figment_relative_path",
                 ];
@@ -1166,7 +1166,7 @@ mod _serde {
                         })
                     }
                 }
-                const FIELDS: &'static [&'static str] =
+                const FIELDS: &[&str] =
                     &["___figment_tagged_tag", "___figment_tagged_value"];
                 _serde::Deserializer::deserialize_struct(
                     __deserializer,

--- a/src/value/parse.rs
+++ b/src/value/parse.rs
@@ -15,10 +15,7 @@ pub fn is_whitespace(&byte: &char) -> bool {
 
 #[inline(always)]
 fn is_not_separator(&byte: &char) -> bool {
-    match byte {
-        ',' | '{' | '}' | '[' | ']' => false,
-        _ => true
-    }
+    !matches!(byte, ',' | '{' | '}' | '[' | ']')
 }
 
 #[inline(always)]
@@ -37,7 +34,7 @@ fn key<'a>(input: &mut Input<'a>) -> Result<'a, String> {
 
 #[parser]
 fn key_value<'a>(input: &mut Input<'a>) -> Result<'a, (String, Value)> {
-    let key = (surrounded(key, is_whitespace)?, eat('=')?).0.to_string();
+    let key = (surrounded(key, is_whitespace)?, eat('=')?).0;
     (key, surrounded(value, is_whitespace)?)
 }
 
@@ -110,6 +107,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)] // false positive: using the PI constant would be wrong here
     fn check_simple_values_parse() {
         assert_parse_eq! {
             "true" => true,

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -125,14 +125,14 @@ impl Serializer for ValueSerializer {
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
         Ok(SeqSerializer {
-            sequence: len.map(|n| Vec::with_capacity(n)).unwrap_or_default()
+            sequence: len.map(Vec::with_capacity).unwrap_or_default()
         })
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
         Ok(MapSerializer {
-            keys: len.map(|n| Vec::with_capacity(n)).unwrap_or_default(),
-            values: len.map(|n| Vec::with_capacity(n)).unwrap_or_default(),
+            keys: len.map(Vec::with_capacity).unwrap_or_default(),
+            values: len.map(Vec::with_capacity).unwrap_or_default(),
         })
     }
 
@@ -295,7 +295,7 @@ impl<'a> ser::SerializeMap for MapSerializer {
     {
         match key.serialize(ValueSerializer)? {
             Value::String(_, s) => self.keys.push(s),
-            v => Err(Kind::UnsupportedKey(v.to_actual(), "string".into()))?
+            v => return Err(Kind::UnsupportedKey(v.to_actual(), "string".into()).into()),
         };
 
         Ok(())

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -136,7 +136,7 @@ impl Value {
     /// assert!(value.clone().find("pineapple").is_none());
     /// ```
     pub fn find(self, path: &str) -> Option<Value> {
-        fn find<'a>(mut keys: Split<'a, char>, value: Value) -> Option<Value> {
+        fn find(mut keys: Split<char>, value: Value) -> Option<Value> {
             match keys.next() {
                 Some(k) if !k.is_empty() => find(keys, value.into_dict()?.remove(k)?),
                 Some(_) | None => Some(value)
@@ -353,9 +353,9 @@ macro_rules! impl_from_array {
 
 impl_from_array!(1, 2, 3, 4, 5, 6, 7, 8);
 
-impl<'a> From<&'a str> for Value {
-    fn from(value: &'a str) -> Value {
-        Value::String(Tag::Default, value.to_string().into())
+impl From<&str> for Value {
+    fn from(value: &str) -> Value {
+        Value::String(Tag::Default, value.to_string())
     }
 }
 


### PR DESCRIPTION
Hi again!
Here I just went through and applied all of the clippy suggestions that made sense in my opinion. Of course I'm open to still changing stuff if it doesn't fit the crate's style/standards.
There are two clippy warnings and one "error" still left:
```
warning: module has the same name as its containing module
 --> src/value/mod.rs:3:1
  |
3 | mod value;
  | ^^^^^^^^^^
  |
  = note: `#[warn(clippy::module_inception)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_inception
```
This one I think is really just a nitpick; clippy would probably like you to remove the nested `value::value` module and move the code to the top-level module, but I don't think there's really a point in that.
```
warning: this import is redundant
   --> src/util.rs:336:1
    |
336 | pub(crate) use cloneable_fn_trait;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it entirely
    |
    = note: `#[warn(clippy::single_component_path_imports)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
```
This is a definite false positive and should probably be reported to clippy if it isn't already; this warning should never apply to macros.
```
error: you are deriving `Hash` but have implemented `PartialEq` explicitly
   --> src/profile.rs:9:32
    |
9   | #[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
    |                                ^^^^
    |
    = note: `#[deny(clippy::derive_hash_xor_eq)]` on by default
note: `PartialEq` implemented here
   --> src/profile.rs:267:1
    |
267 | / impl PartialEq<Profile> for &Profile {
268 | |     fn eq(&self, other: &Profile) -> bool {
269 | |         self.as_str() == other.as_str()
270 | |     }
271 | | }
    | |_^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
```
Not sure what to do about this one, but I doubt that it has any real impact.