### PR TITLE
Use atomic crate to handle atomic types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,30 @@ jobs:
       - name: Run Tests
         run: ./scripts/test.sh
         shell: bash
+
+  test_cross:
+    name: Linux ARMv7 (${{ matrix.toolchain }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [nightly, stable]
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          target: armv7-unknown-linux-gnueabihf
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target armv7-unknown-linux-gnueabihf --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ serde_yaml = { version = "0.8", optional = true }
 tempfile = { version = "3", optional = true }
 parking_lot = { version = "0.11", optional = true }
 
+[target.'cfg(any(target_pointer_width = "8", target_pointer_width = "16", target_pointer_width = "32"))'.dependencies]
+atomic = "0.5.0"
+
 [dev-dependencies]
 tempfile = "3"
 parking_lot = "0.11"

--- a/src/value/tag.rs
+++ b/src/value/tag.rs
@@ -1,9 +1,8 @@
 use std::fmt;
-use std::sync::atomic::{Ordering, AtomicU64};
+use std::sync::atomic::Ordering;
 
 use serde::{de, ser};
 use crate::profile::{Profile, ProfileTag};
-
 /// An opaque, unique tag identifying a value's [`Metadata`](crate::Metadata)
 /// and profile.
 ///
@@ -17,7 +16,12 @@ use crate::profile::{Profile, ProfileTag};
 #[derive(Copy, Clone)]
 pub struct Tag(u64);
 
-static COUNTER: AtomicU64 = AtomicU64::new(1);
+#[cfg(any(target_pointer_width = "8", target_pointer_width = "16", target_pointer_width = "32"))]
+static COUNTER: atomic::Atomic<u64> = atomic::Atomic::new(1);
+
+#[cfg(not(any(target_pointer_width = "8", target_pointer_width = "16", target_pointer_width = "32")))]
+static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
 
 impl Tag {
     /// The default `Tag`. Such a tag will never have associated metadata and


### PR DESCRIPTION
This would resolve issue #7 which makes it impossible to build this crate on targets which do not support AtomicU64. 
The problem was resolved by using the `atomic` crate which uses the normal atomics where they are supported and uses fallbacks where they are not supported. Because the real atomic types are used on supported platforms there shouldn't be a performance penalty.