### PR TITLE
Update lib.rs to make coalesce module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,9 +477,9 @@ pub mod value;
 pub mod providers;
 pub mod error;
 pub mod util;
+pub mod coalesce;
 mod figment;
 mod profile;
-mod coalesce;
 mod metadata;
 mod provider;
 


### PR DESCRIPTION
The coalesce module was not accessible when building a custom provider that required to merge a Dict