### PR TITLE
fix typos in docs for `Profile::from_env` & `Profile::from_env_or`

### DIFF
--- a/src/profile.rs
+++ b/src/profile.rs
@@ -97,7 +97,7 @@ impl Profile {
     }
 
     /// Constructs a profile from the value of the environment variable with
-    /// name `name`, if one is present. The search for `name` is
+    /// name `key`, if one is present. The search for `key` is
     /// case-insensitive.
     ///
     /// # Example
@@ -127,8 +127,8 @@ impl Profile {
     }
 
     /// Constructs a profile from the value of the environment variable with
-    /// name `name`, if one is present, or `default` if one is not. The search
-    /// for `name` is case-insensitive.
+    /// name `var`, if one is present, or `default` if one is not. The search
+    /// for `var` is case-insensitive.
     ///
     /// # Example
     ///


### PR DESCRIPTION
I found some mismatch from the docs to the parameter of  `Profile::from_env` & `Profile::from_env_or`, in which the `name` from docs may be some typo.