### PR TITLE
Allow dots in keys of maps

### DIFF
--- a/src/providers/env.rs
+++ b/src/providers/env.rs
@@ -287,12 +287,16 @@ impl Env {
     /// Jail::expect_with(|jail| {
     ///     // Without splitting: using structured data.
     ///     jail.set_env("APP_FOO", "{key=10}");
-    ///     jail.set_env("APP_MAP", "{one=1,two=2.0}");
+    ///     jail.set_env("APP_MAP", "{one=1,two=2.0,three.one=3.1}");
     ///
     ///     let config: Config = Figment::from(Env::prefixed("APP_")).extract()?;
     ///     assert_eq!(config, Config {
     ///         foo: Foo { key: 10 },
-    ///         map: map!["one".into() => 1u8.into(), "two".into() => 2.0.into()],
+    ///         map: map![
+    ///             "one".into() => 1u8.into(),
+    ///             "two".into() => 2.0.into(),
+    ///             "three.one".into() =>  3.1.into(),
+    ///         ],
     ///     });
     ///
     ///     // With splitting.
@@ -306,7 +310,11 @@ impl Env {
     ///
     ///     assert_eq!(config, Config {
     ///         foo: Foo { key: 20 },
-    ///         map: map!["one".into() => 1.0.into(), "two".into() => "dos".into()],
+    ///         map: map![
+    ///             "one".into() => 1.0.into(),
+    ///             "two".into() => "dos".into(),
+    ///             "three.one".into() =>  3.1.into(),
+    ///         ],
     ///     });
     ///
     ///     Ok(())

--- a/src/value/parse.rs
+++ b/src/value/parse.rs
@@ -21,7 +21,7 @@ fn is_not_separator(&byte: &char) -> bool {
 // TODO: Be more permissive here?
 #[inline(always)]
 fn is_ident_char(&byte: &char) -> bool {
-    byte.is_ascii_alphanumeric() || byte == '_' || byte == '-'
+    byte.is_ascii_alphanumeric() || byte == '_' || byte == '-' || byte == '.'
 }
 
 #[parser]
@@ -166,6 +166,7 @@ mod tests {
         assert_parse_eq! {
             "[1,2,3]" => vec![1u8, 2u8, 3u8],
             "{a=b}" => map!["a" => "b"],
+            "{a.b=c}" => map!["a.b" => "c"],
             "{a=1,b=3}" => map!["a" => 1u8, "b" => 3u8],
             "{a=1,b=hi}" => map!["a" => v(1u8), "b" => v("hi")],
             "[1,[2],3]" => vec![v(1u8), v(vec![2u8]), v(3u8)],


### PR DESCRIPTION
This PR allows users to have keys with dots in map. For example, I have this TOML configuration:

```toml
[registries.'registry.gitlab.com']
username = "oauth2"
password = "your-private-token"
```

I'm using it with figment and I want to be able to place that configuration to an env variable that is managed as a sealed secret in Kubernetes. The variable could look like this (using `PREVANT_` prefix):

```
PREVANT_REGISTRIES="{registry.gitlab.com={username="oauth2",password="your-private-token"}}"
```

This PR fixes it.