### PR TITLE
Add `admerge` as an additional coalescing strategy

### DIFF
--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -6,6 +6,7 @@ pub enum Order {
     Merge,
     Join,
     Adjoin,
+    Admerge,
 }
 
 pub trait Coalescible: Sized {
@@ -17,7 +18,7 @@ impl Coalescible for Profile {
     fn coalesce(self, other: Self, order: Order) -> Self {
         match order {
             Order::Join | Order::Adjoin => self,
-            Order::Merge => other,
+            Order::Merge | Order::Admerge => other,
         }
     }
 }
@@ -26,9 +27,9 @@ impl Coalescible for Value {
     fn coalesce(self, other: Self, o: Order) -> Self {
         use {Value::Dict as D, Value::Array as A, Order::*};
         match (self, other, o) {
-            (D(t, a), D(_, b), Join | Adjoin) | (D(_, a), D(t, b), Merge) => D(t, a.coalesce(b, o)),
-            (A(t, mut a), A(_, b), Adjoin) => A(t, { a.extend(b); a }),
-            (v, _, Join | Adjoin) | (_, v, Merge) => v,
+            (D(t, a), D(_, b), Join | Adjoin) | (D(_, a), D(t, b), Merge | Admerge) => D(t, a.coalesce(b, o)),
+            (A(t, mut a), A(_, b), Adjoin | Admerge) => A(t, { a.extend(b); a }),
+            (v, _, Join | Adjoin) | (_, v, Merge | Admerge) => v,
         }
     }
 }

--- a/src/figment.rs
+++ b/src/figment.rs
@@ -110,7 +110,7 @@ use crate::coalesce::{Coalescible, Order};
 ///     .join(("key", "value"))
 ///     .join(("map", map!["inner" => vec!["hello"]]))
 ///     .adjoin(("k", vec![4, 5]))
-///     .adjoin("key", "val")
+///     .adjoin(("key", "val"))
 ///     .adjoin(("map", map!["inner" => vec!["world"]]));
 ///
 /// let vec: Vec<u8> = figment.extract_inner("k").unwrap();
@@ -125,7 +125,7 @@ use crate::coalesce::{Coalescible, Order};
 ///     .join(("key", "value"))
 ///     .join(("map", map!["inner" => vec!["hello"]]))
 ///     .admerge(("k", vec![4, 5]))
-///     .admerge("key", "val")
+///     .admerge(("key", "val"))
 ///     .admerge(("map", map!["inner" => vec!["world"]]));
 ///
 /// let vec: Vec<u8> = figment.extract_inner("k").unwrap();

--- a/src/figment.rs
+++ b/src/figment.rs
@@ -210,49 +210,8 @@ impl Figment {
         self.provide(provider, Order::Join)
     }
 
-    /// Adjoins `provider` into the current figment. See [merging vs.
-    /// joining](#merging-vs-joining) for details.
-    ///
-    /// ```rust
-    /// use figment::Figment;
-    /// use figment::providers::Env;
-    /// use figment::util::map;
-    /// use figment::value::{Dict, Map};
-    ///
-    /// // With `adjoin`, arrays are concatened on conflict:
-    /// let figment = Figment::new()
-    ///     .join(("k", vec![1, 2, 3]))
-    ///     .join(("map", map!["inner" => vec!["hello"]]))
-    ///     .adjoin(("k", vec![4, 5]))
-    ///     .adjoin(("map", map!["inner" => vec!["world"]]));
-    ///
-    /// let vec: Vec<u8> = figment.extract_inner("k").unwrap();
-    /// let inner: Vec<String> = figment.extract_inner("map.inner").unwrap();
-    /// assert_eq!(vec, vec![1, 2, 3, 4, 5]);
-    /// assert_eq!(inner, vec!["hello", "world"]);
-    ///
-    /// // This is not the case with `join`, which takes the former value.
-    /// let figment = Figment::from(("k", vec![1, 2, 3]))
-    ///     .join(("map", map!["inner" => vec!["hello"]]))
-    ///     .join(("k", vec![4, 5]))
-    ///     .join(("map", map!["inner" => vec!["world"]]));
-    ///
-    /// let vec: Vec<u8> = figment.extract_inner("k").unwrap();
-    /// let inner: Vec<String> = figment.extract_inner("map.inner").unwrap();
-    /// assert_eq!(vec, vec![1, 2, 3]);
-    /// assert_eq!(inner, vec!["hello"]);
-    ///
-    /// // Nor `merge`, which takes the latter value.
-    /// let figment = Figment::from(("k", vec![1, 2, 3]))
-    ///     .join(("map", map!["inner" => vec!["hello"]]))
-    ///     .merge(("k", vec![4, 5]))
-    ///     .merge(("map", map!["inner" => vec!["world"]]));
-    ///
-    /// let vec: Vec<u8> = figment.extract_inner("k").unwrap();
-    /// let inner: Vec<String> = figment.extract_inner("map.inner").unwrap();
-    /// assert_eq!(vec, vec![4, 5]);
-    /// assert_eq!(inner, vec!["world"]);
-    /// ```
+    /// Joins `provider` into the current figment while concatenating vectors.
+    /// See [merging vs. joining](#merging-vs-joining) for details.
     #[track_caller]
     pub fn adjoin<T: Provider>(self, provider: T) -> Self {
         self.provide(provider, Order::Adjoin)
@@ -271,6 +230,13 @@ impl Figment {
     #[track_caller]
     pub fn merge<T: Provider>(self, provider: T) -> Self {
         self.provide(provider, Order::Merge)
+    }
+
+    /// Merges `provider` into the current figment while concatenating vectors.
+    /// See [merging vs. joining](#merging-vs-joining) for details.
+    #[track_caller]
+    pub fn admerge<T: Provider>(self, provider: T) -> Self {
+        self.provide(provider, Order::Admerge)
     }
 
     /// Sets the profile to extract from to `profile`.


### PR DESCRIPTION
## Description

This PR
- adds `admerge` as a coalescing strategy which
  - overwrites an existing non-array values (like `merge`)
  - concatenates arrays (like `adjoin`)
- updates documentation to include information about this function

## Examples

```json
{ "a": [1, 2], "b": "value" }
```

```json
{ "a": [3, 4], "b": "new_value" }
```

**adjoin:**
```json
{ "a": [1, 2, 3, 4], "b": "value" }
```

**admerge:**
```json
{ "a": [1, 2, 3, 4], "b": "new_value" }
````
