### PR TITLE
Flexible inputs, second attempt

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -14,6 +14,7 @@ mod escape;
 pub mod magic;
 
 pub(crate) use {self::ser::*, self::de::*};
+
 pub use tag::Tag;
 pub use value::{Value, Map, Num, Dict, Empty};
 pub use uncased::{Uncased, UncasedStr};

--- a/tests/lossy_values.rs
+++ b/tests/lossy_values.rs
@@ -1,0 +1,28 @@
+use serde::Deserialize;
+use figment::{Figment, providers::{Toml, Format}};
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Config {
+    bs: Vec<bool>,
+    u8s: Vec<u8>,
+    i32s: Vec<i32>,
+    f64s: Vec<f64>,
+}
+
+static TOML: &str = r##"
+    u8s = [1, 2, 3, "4", 5, "6"]
+    i32s = [-1, -2, 3, "-4", 5, "6"]
+    f64s = [1, "2", -3, -4.5, "5.0", "-6.0"]
+    bs = [true, false, "true", "false", "YES", "no", "on", "OFF", "1", "0", 1, 0]
+"##;
+
+#[test]
+fn lossy_values() {
+    let config: Config = Figment::from(Toml::string(TOML)).extract_lossy().unwrap();
+    assert_eq!(&config.u8s, &[ 1, 2, 3, 4, 5, 6 ]);
+    assert_eq!(&config.i32s, &[-1, -2, 3, -4, 5, 6]);
+    assert_eq!(&config.f64s, &[1.0, 2.0, -3.0, -4.5, 5.0, -6.0]);
+    assert_eq!(&config.bs, &[
+        true, false, true, false, true, false, true, false, true, false, true, false
+    ]);
+}


### PR DESCRIPTION
This is a second attempt to implement the idea of #97.

Instead of changing the default behavior of `impl Deserialize for *`, it instead provides new `extract_lossy` and `extract_inner_lossy` methods that implement the lossy behavior across the entire figment object.

(As an alternative, as discussed on #97, the user might annotate all their booleans and numbers with `deserialize_with`.  But it can be error-prone to do so, especially if the configuration structure is large and complex.)