### PR TITLE
Use `toml_edit` directly instead of `toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
 target/
 **/*.rs.bk
-
-
-# Added by cargo
-#
-# already existing elements were commented out
-
-#/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,18 @@ license = "MIT OR Apache-2.0"
 categories = ["config"]
 
 [features]
-env = ["pear", "parse-value"]
+env = ["parse-value"]
 json = ["serde_json"]
-yaml = ["serde_yaml"]
 parse-value = ["pear"]
 test = ["tempfile", "parking_lot"]
-# toml = ["toml"]
+toml = ["toml_edit"]
+yaml = ["serde_yaml"]
 
 [dependencies]
-serde = { version = "1.0" }
+serde = "1.0"
 uncased = "0.9.3"
 pear = { version = "0.2", optional = true }
-toml = { version = "0.8", optional = true }
+toml_edit = { version = "0.22", optional = true, default-features = false, features = ["parse", "serde"] }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 tempfile = { version = "3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "figment"
-version = "0.10.18"
+version = "0.10.19"
 authors = ["Sergio Benitez <sb@sergio.bz>"]
 edition = "2018"
 documentation = "https://docs.rs/figment/0.10"

--- a/src/providers/data.rs
+++ b/src/providers/data.rs
@@ -518,7 +518,7 @@ impl YamlExtended {
     }
 }
 
-impl_format!(Toml "TOML"/"toml": toml::from_str, toml::de::Error);
+impl_format!(Toml "TOML"/"toml": toml_edit::de::from_str, toml_edit::de::Error);
 impl_format!(Yaml "YAML"/"yaml": serde_yaml::from_str, serde_yaml::Error);
 impl_format!(Json "JSON"/"json": serde_json::from_str, serde_json::error::Error);
 impl_format!(YamlExtended "YAML Extended"/"yaml": YamlExtended::from_str, serde_yaml::Error);


### PR DESCRIPTION
I replaced the `toml` crate with `toml_edit`. The `toml` crate uses `toml_edit` under the hood anyway (see https://epage.github.io/blog/2023/01/toml-vs-toml-edit by the author of both crates).
There is one change caused by this move: The `display` feature of `toml_edit` is not enabled now which means that we only activate what we use (`serde` and `parse`).