### PR TITLE
Allow integer indexing

### DIFF
--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -1,5 +1,5 @@
 use crate::Profile;
-use crate::value::{Value, Map};
+use crate::value::{Map, Value};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Order {
@@ -7,6 +7,8 @@ pub enum Order {
     Join,
     Adjoin,
     Admerge,
+    Zipjoin,
+    Zipmerge,
 }
 
 pub trait Coalescible: Sized {
@@ -17,8 +19,8 @@ pub trait Coalescible: Sized {
 impl Coalescible for Profile {
     fn coalesce(self, other: Self, order: Order) -> Self {
         match order {
-            Order::Join | Order::Adjoin => self,
-            Order::Merge | Order::Admerge => other,
+            Order::Join | Order::Adjoin | Order::Zipjoin => self,
+            Order::Merge | Order::Admerge | Order::Zipmerge => other,
         }
     }
 }
@@ -27,9 +29,10 @@ impl Coalescible for Value {
     fn coalesce(self, other: Self, o: Order) -> Self {
         use {Value::Dict as D, Value::Array as A, Order::*};
         match (self, other, o) {
-            (D(t, a), D(_, b), Join | Adjoin) | (D(_, a), D(t, b), Merge | Admerge) => D(t, a.coalesce(b, o)),
+            (D(t, a), D(_, b), Join | Adjoin | Zipjoin) | (D(_, a), D(t, b), Merge | Admerge | Zipmerge) => D(t, a.coalesce(b, o)),
             (A(t, mut a), A(_, b), Adjoin | Admerge) => A(t, { a.extend(b); a }),
-            (v, _, Join | Adjoin) | (_, v, Merge | Admerge) => v,
+            (A(t, a), A(_, b), Zipjoin | Zipmerge) => A(t, a.coalesce(b, o)),
+            (v, _, Join | Adjoin | Zipjoin) | (_, v, Merge | Admerge | Zipmerge) => v,
         }
     }
 }
@@ -47,5 +50,113 @@ impl<K: Eq + std::hash::Hash + Ord, V: Coalescible> Coalescible for Map<K, V> {
         // `b` contains `b - a`, i.e, additions. keep them all.
         joined.extend(other);
         joined
+    }
+}
+
+impl Coalescible for Vec<Value> {
+    fn coalesce(self, other: Self, order: Order) -> Self {
+        let mut zipped = Vec::new();
+        let mut other = other.into_iter();
+
+        // Coalesces self[0] with other[0], self[1] with other[1] and so on.
+        for a_val in self.into_iter() {
+            match other.next() {
+                // Special cases: either a or b has an empty value, in which
+                // case we always choose the non-empty one regardless of order.
+                // If both are empty we just push either of the empties.
+                Some(b_val) if a_val.is_none() => zipped.push(b_val),
+                Some(b_val) if b_val.is_none() => zipped.push(a_val),
+
+                Some(b_val) => zipped.push(a_val.coalesce(b_val, order)),
+                None => zipped.push(a_val),
+            };
+        }
+
+        // `b` contains more items than `a`; append them all.
+        zipped.extend(other);
+        zipped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::value::Empty;
+    use crate::{map, value::Value};
+    use crate::coalesce::{Coalescible, Order};
+
+    #[test]
+    pub fn coalesce_values() {
+        fn a() -> Value { Value::from("a") }
+        fn b() -> Value { Value::from("b") }
+
+        fn expect(order: Order, result: Value) { assert_eq!(a().coalesce(b(), order), result) }
+
+        expect(Order::Merge, b());
+        expect(Order::Admerge, b());
+        expect(Order::Zipmerge, b());
+        expect(Order::Join, a());
+        expect(Order::Adjoin, a());
+        expect(Order::Zipjoin, a());
+    }
+
+    #[test]
+    pub fn coalesce_dicts() {
+        fn a() -> Value { Value::from(map!(
+            "a" => map!("one" => 1, "two" => 2),
+            "b" => map!("ten" => 10, "twenty" => 20),
+        )) }
+        fn b() -> Value { Value::from(map!(
+            "a" => map!("one" => 2, "three" => 3),
+            "b" => map!("ten" => 20, "thirty" => 30),
+        )) }
+        fn result_join() -> Value { Value::from(map!(
+            "a" => map!("one" => 1, "two" => 2, "three" => 3),
+            "b" => map!("ten" => 10, "twenty" => 20, "thirty" => 30),
+        )) }
+        fn result_merge() -> Value { Value::from(map!(
+            "a" => map!("one" => 2, "two" => 2, "three" => 3),
+            "b" => map!("ten" => 20, "twenty" => 20, "thirty" => 30),
+        )) }
+
+        fn expect(order: Order, result: Value) { assert_eq!(a().coalesce(b(), order), result) }
+
+        expect(Order::Merge, result_merge());
+        expect(Order::Admerge, result_merge());
+        expect(Order::Zipmerge, result_merge());
+        expect(Order::Join, result_join());
+        expect(Order::Adjoin, result_join());
+        expect(Order::Zipjoin, result_join());
+    }
+
+    #[test]
+    pub fn coalesce_arrays() {
+        fn a() -> Value { Value::from(vec![1, 2]) }
+        fn b() -> Value { Value::from(vec![2, 3, 4]) }
+
+        fn expect(order: Order, result: Value) { assert_eq!(a().coalesce(b(), order), result) }
+
+        expect(Order::Merge, Value::from(vec![2, 3, 4]));
+        expect(Order::Admerge, Value::from(vec![1, 2, 2, 3, 4]));
+        expect(Order::Zipmerge, Value::from(vec![2, 3, 4]));
+        expect(Order::Join, Value::from(vec![1, 2]));
+        expect(Order::Adjoin, Value::from(vec![1, 2, 2, 3, 4]));
+        expect(Order::Zipjoin, Value::from(vec![1, 2, 4]));
+    }
+
+    #[test]
+    pub fn coalesce_arrays_empty() {
+        fn e() -> Value { Value::from(Empty::None) }
+        fn v(i: i32) -> Value { Value::from(i) }
+        fn a() -> Value { Value::from(vec![v(50), e(), v(4)]) }
+        fn b() -> Value { Value::from(vec![e(), v(2), v(6), e(), v(20)]) }
+
+        fn expect(order: Order, result: Value) { assert_eq!(a().coalesce(b(), order), result) }
+
+        expect(Order::Merge, Value::from(vec![e(), v(2), v(6), e(), v(20)]));
+        expect(Order::Admerge, Value::from(vec![v(50), e(), v(4), e(), v(2), v(6), e(), v(20)]));
+        expect(Order::Zipmerge, Value::from(vec![v(50), v(2), v(6), e(), v(20)]));
+        expect(Order::Join, Value::from(vec![v(50), e(), v(4)]));
+        expect(Order::Adjoin, Value::from(vec![v(50), e(), v(4), e(), v(2), v(6), e(), v(20)]));
+        expect(Order::Zipjoin, Value::from(vec![v(50), v(2), v(4), e(), v(20)]));
     }
 }

--- a/src/figment.rs
+++ b/src/figment.rs
@@ -25,9 +25,9 @@ use crate::coalesce::{Coalescible, Order};
 /// resolved via one of six strategies: [`join`], [`adjoin`], [`zipjoin`],
 /// [`merge`], [`admerge`], and [`zipmerge`]. In general, the `-join` strategies
 /// prefer existing values while the `-merge` strategies prefer later values.
-/// The `ad-` strategies additionally concatenate arrays, the `zip-` strategies
-/// combine both of the first items, both of the second items and so on, whereas
-/// the unprefixed strategies treat arrays as non-composite values.
+/// The `ad-` strategies additionally concatenate arrays; the `zip-` strategies
+/// treat array indices as keys resulting in index-wise joining (for zipjoin)
+/// or merging (for zipmerge) arrays while preserving all excess elements.
 ///
 /// The table below summarizes these strategies and their behavior, with the
 /// column label referring to the type of the value pointed to by the
@@ -53,7 +53,8 @@ use crate::coalesce::{Coalescible, Order};
 ///   * `join` uses the existing value
 ///   * `merge` uses the incoming value
 ///   * `adjoin` and `admerge` concatenate the arrays
-///   * `zipjoin` and `zipmerge` combine array items with equal index
+///   * `zipjoin` index-wise joins the arrays and keeps excess values
+///   * `zipmerge` index-wise merges the arrays and keeps excess values
 ///
 /// If both keys point to a **non-composite** (`String`, `Num`, etc.) or values
 /// of different kinds (i.e, **array** and **num**):

--- a/src/figment.rs
+++ b/src/figment.rs
@@ -388,6 +388,12 @@ impl Figment {
     ///         [subtree.bark]
     ///         dog = true
     ///         cat = false
+    ///
+    ///         [[lives]]
+    ///         cat = 9
+    ///
+    ///         [[lives]]
+    ///         dog = 1
     ///     "#)?;
     ///
     ///     let root = Figment::from(Toml::file("Config.toml"));
@@ -409,6 +415,15 @@ impl Figment {
     ///     let not_a_dict = root.focus("cat");
     ///     assert!(not_a_dict.extract_inner::<bool>("cat").is_err());
     ///     assert!(not_a_dict.extract_inner::<bool>("dog").is_err());
+    ///
+    ///     let cat_lives = root.focus("lives.0");
+    ///     assert_eq!(cat_lives.extract_inner::<u8>("cat").unwrap(), 9);
+    ///     let dog_lives = root.focus("lives.1");
+    ///     assert_eq!(dog_lives.extract_inner::<u8>("dog").unwrap(), 1);
+    ///
+    ///     let invalid_index = root.focus("lives.two");
+    ///     assert!(invalid_index.extract_inner::<bool>("cat").is_err());
+    ///     assert!(invalid_index.extract_inner::<bool>("dog").is_err());
     ///
     ///     Ok(())
     /// });

--- a/src/providers/env.rs
+++ b/src/providers/env.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::{Profile, Provider, Metadata};
-use crate::coalesce::Coalescible;
+use crate::coalesce::{Coalescible, Order};
 use crate::value::{Map, Dict};
 use crate::error::Error;
 use crate::util::nest;
@@ -395,23 +395,33 @@ impl Env {
     /// struct Config {
     ///     foo: Foo,
     ///     map: Dict,
+    ///     array: Vec<usize>,
     /// }
     ///
     /// Jail::expect_with(|jail| {
     ///     // Without splitting: using structured data.
     ///     jail.set_env("APP_FOO", "{key=10}");
     ///     jail.set_env("APP_MAP", "{one=1,two=2.0}");
+    ///     jail.set_env("APP_ARRAY", "[1,2,3]");
     ///
     ///     let config: Config = Figment::from(Env::prefixed("APP_")).extract()?;
     ///     assert_eq!(config, Config {
     ///         foo: Foo { key: 10 },
     ///         map: map!["one".into() => 1u8.into(), "two".into() => 2.0.into()],
+    ///         array: vec![1, 2, 3],
     ///     });
+    ///
+    ///     jail.clear_env();
     ///
     ///     // With splitting.
     ///     jail.set_env("APP_FOO_KEY", 20);
     ///     jail.set_env("APP_MAP_ONE", "1.0");
     ///     jail.set_env("APP_MAP_TWO", "dos");
+    ///
+    ///     // Note that array order currently depends on definition order
+    ///     jail.set_env("APP_ARRAY_0", "4");
+    ///     jail.set_env("APP_ARRAY_2", "5");
+    ///     jail.set_env("APP_ARRAY_1", "6");
     ///
     ///     let config: Config = Figment::new()
     ///         .merge(Env::prefixed("APP_").split("_"))
@@ -420,6 +430,7 @@ impl Env {
     ///     assert_eq!(config, Config {
     ///         foo: Foo { key: 20 },
     ///         map: map!["one".into() => 1.0.into(), "two".into() => "dos".into()],
+    ///         array: vec![4, 5, 6],
     ///     });
     ///
     ///     Ok(())
@@ -637,7 +648,7 @@ impl Provider for Env {
                 .into_dict()
                 .expect("key is non-empty: must have dict");
 
-            dict = dict.merge(nested_dict);
+            dict = dict.coalesce(nested_dict, Order::Admerge);
         }
 
         Ok(self.profile.collect(dict))

--- a/src/providers/env.rs
+++ b/src/providers/env.rs
@@ -417,11 +417,9 @@ impl Env {
     ///     jail.set_env("APP_FOO_KEY", 20);
     ///     jail.set_env("APP_MAP_ONE", "1.0");
     ///     jail.set_env("APP_MAP_TWO", "dos");
-    ///
-    ///     // Note that array order currently depends on definition order
     ///     jail.set_env("APP_ARRAY_0", "4");
-    ///     jail.set_env("APP_ARRAY_2", "5");
-    ///     jail.set_env("APP_ARRAY_1", "6");
+    ///     jail.set_env("APP_ARRAY_2", "6");
+    ///     jail.set_env("APP_ARRAY_1", "5");
     ///
     ///     let config: Config = Figment::new()
     ///         .merge(Env::prefixed("APP_").split("_"))
@@ -648,7 +646,7 @@ impl Provider for Env {
                 .into_dict()
                 .expect("key is non-empty: must have dict");
 
-            dict = dict.coalesce(nested_dict, Order::Admerge);
+            dict = dict.coalesce(nested_dict, Order::Zipmerge);
         }
 
         Ok(self.profile.collect(dict))

--- a/src/providers/env.rs
+++ b/src/providers/env.rs
@@ -76,6 +76,10 @@ crate::util::cloneable_fn_trait!(
 /// environment variable `Value`. For example, the environment variable
 /// `a.b.c=3` creates the mapping `a -> b -> c -> 3` in the emitted data.
 ///
+/// The created dictionaries are then zipmerged, which allows multiple variables
+/// like `array.2=24` to form one array, as well as overwriting single values in
+/// existing arrays.
+///
 /// Environment variable names cannot typically contain the `.` character, but
 /// another character can be used in its place by replacing that character in
 /// the name with `.` with [`Env::map()`]. The [`Env::split()`] method is a
@@ -410,8 +414,6 @@ impl Env {
     ///         map: map!["one".into() => 1u8.into(), "two".into() => 2.0.into()],
     ///         array: vec![1, 2, 3],
     ///     });
-    ///
-    ///     jail.clear_env();
     ///
     ///     // With splitting.
     ///     jail.set_env("APP_FOO_KEY", 20);

--- a/src/util.rs
+++ b/src/util.rs
@@ -239,7 +239,7 @@ pub mod vec_tuple_map {
     }
 }
 
-use crate::value::{Value, Dict};
+use crate::value::{Dict, Empty, Value};
 
 /// Given a key path `key` of the form `a.b.c`, creates nested dictionaries for
 /// for every path component delimited by `.` in the path string (3 in `a.b.c`),
@@ -270,21 +270,25 @@ use crate::value::{Value, Dict};
 /// ```
 pub fn nest(key: &str, value: Value) -> Value {
     fn value_from(mut keys: std::str::Split<'_, char>, value: Value) -> Value {
-        match keys.next() {
-            Some(k) if k.parse::<usize>().is_ok() => {
-                // TODO
-                // even if we do honor the index, it will get lost when coalescing.
-                // seems to me that nesting arrays will only be truly useful when
-                // coalescing two array items by their index is possible.
-                Value::from(vec![value_from(keys, value)])
-            }
-            Some(k) if !k.is_empty() => {
-                let mut dict = Dict::new();
-                dict.insert(k.into(), value_from(keys, value));
-                dict.into()
-            }
-            Some(_) | None => value
+        let Some(key) = keys.next() else {
+            return value;
+        };
+
+        if let Ok(index) = key.parse::<usize>() {
+            let mut vec = vec![Value::from(Empty::None); index + 1];
+            vec[index] = value_from(keys, value);
+
+            return Value::from(vec);
         }
+
+        if !key.is_empty() {
+            let mut dict = Dict::new();
+            dict.insert(key.into(), value_from(keys, value));
+
+            return dict.into()
+        }
+
+        value
     }
 
     value_from(key.split('.'), value)

--- a/src/util.rs
+++ b/src/util.rs
@@ -271,6 +271,13 @@ use crate::value::{Value, Dict};
 pub fn nest(key: &str, value: Value) -> Value {
     fn value_from(mut keys: std::str::Split<'_, char>, value: Value) -> Value {
         match keys.next() {
+            Some(k) if k.parse::<usize>().is_ok() => {
+                // TODO
+                // even if we do honor the index, it will get lost when coalescing.
+                // seems to me that nesting arrays will only be truly useful when
+                // coalescing two array items by their index is possible.
+                Value::from(vec![value_from(keys, value)])
+            }
             Some(k) if !k.is_empty() => {
                 let mut dict = Dict::new();
                 dict.insert(k.into(), value_from(keys, value));

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -426,6 +426,10 @@ impl Value {
         }
     }
 
+    pub(crate) fn is_none(&self) -> bool {
+        matches!(self, Value::Empty(_, Empty::None))
+    }
+
     /// Attempts to retrieve a nested value through dictionary key or array index.
     pub(crate) fn index(self, key: &str) -> Option<Value> {
         fn try_remove<T>(mut vec: Vec<T>, key: &str) -> Option<T> {


### PR DESCRIPTION
Closes #92.

This PR contains a few related changes for various issues:
- Indexing arrays in `Value::find()` (#92)
- Providing partial array values from Env (#113)
- Necessitated by the Env change, new strategies zipjoin/zipmerge, which allow partially overwriting arrays and values inside arrays.