### PR TITLE
Run cargo-fmt and add a CI action to check formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  cargo-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --all -- --check
   test:
     name: "${{ matrix.os.name }} ${{ matrix.test.name }} (${{ matrix.toolchain }})"
     continue-on-error: false

--- a/src/coalesce.rs
+++ b/src/coalesce.rs
@@ -1,5 +1,5 @@
+use crate::value::{Map, Value};
 use crate::Profile;
-use crate::value::{Value, Map};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Order {
@@ -11,7 +11,9 @@ pub enum Order {
 
 pub trait Coalescible: Sized {
     fn coalesce(self, other: Self, order: Order) -> Self;
-    fn merge(self, other: Self) -> Self { self.coalesce(other, Order::Merge) }
+    fn merge(self, other: Self) -> Self {
+        self.coalesce(other, Order::Merge)
+    }
 }
 
 impl Coalescible for Profile {
@@ -25,10 +27,15 @@ impl Coalescible for Profile {
 
 impl Coalescible for Value {
     fn coalesce(self, other: Self, o: Order) -> Self {
-        use {Value::Dict as D, Value::Array as A, Order::*};
+        use {Order::*, Value::Array as A, Value::Dict as D};
         match (self, other, o) {
-            (D(t, a), D(_, b), Join | Adjoin) | (D(_, a), D(t, b), Merge | Admerge) => D(t, a.coalesce(b, o)),
-            (A(t, mut a), A(_, b), Adjoin | Admerge) => A(t, { a.extend(b); a }),
+            (D(t, a), D(_, b), Join | Adjoin) | (D(_, a), D(t, b), Merge | Admerge) => {
+                D(t, a.coalesce(b, o))
+            }
+            (A(t, mut a), A(_, b), Adjoin | Admerge) => A(t, {
+                a.extend(b);
+                a
+            }),
             (v, _, Join | Adjoin) | (_, v, Merge | Admerge) => v,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,11 @@
 //! Error values produces when extracting configurations.
 
-use std::fmt::{self, Display};
 use std::borrow::Cow;
+use std::fmt::{self, Display};
 
-use serde::{ser, de};
+use serde::{de, ser};
 
-use crate::{Figment, Profile, Metadata, value::Tag};
+use crate::{value::Tag, Figment, Metadata, Profile};
 
 /// A simple alias to `Result` with an error type of [`Error`].
 pub type Result<T> = std::result::Result<T, Error>;
@@ -158,8 +158,7 @@ impl Error {
         let mut error = Some(&mut self);
         while let Some(e) = error {
             e.metadata = config.get_metadata(e.tag).cloned();
-            e.profile = e.tag.profile()
-                .or_else(|| Some(config.profile().clone()));
+            e.profile = e.tag.profile().or_else(|| Some(config.profile().clone()));
 
             error = e.prev.as_deref_mut();
         }
@@ -197,7 +196,8 @@ impl Error {
     /// assert_eq!(error.path, vec!["some", "path"]);
     /// ```
     pub fn with_path(mut self, path: &str) -> Self {
-        let paths = path.split('.')
+        let paths = path
+            .split('.')
             .filter(|v| !v.is_empty())
             .map(|v| v.to_string());
 
@@ -365,7 +365,7 @@ impl From<de::Unexpected<'_>> for Actual {
             de::Unexpected::NewtypeVariant => Actual::NewtypeVariant,
             de::Unexpected::TupleVariant => Actual::TupleVariant,
             de::Unexpected::StructVariant => Actual::StructVariant,
-            de::Unexpected::Other(v) => Actual::Other(v.into())
+            de::Unexpected::Other(v) => Actual::Other(v.into()),
         }
     }
 }
@@ -444,12 +444,17 @@ impl Display for Kind {
             }
             Kind::InvalidValue(v, exp) => {
                 write!(f, "invalid value {}, expected {}", v, exp)
-            },
+            }
             Kind::InvalidLength(v, exp) => {
                 write!(f, "invalid length {}, expected {}", v, exp)
-            },
+            }
             Kind::UnknownVariant(v, exp) => {
-                write!(f, "unknown variant: found `{}`, expected `{}`", v, OneOf(exp))
+                write!(
+                    f,
+                    "unknown variant: found `{}`, expected `{}`",
+                    v,
+                    OneOf(exp)
+                )
             }
             Kind::UnknownField(v, exp) => {
                 write!(f, "unknown field: found `{}`, expected `{}`", v, OneOf(exp))
@@ -518,7 +523,9 @@ impl fmt::Display for OneOf {
             _ => {
                 write!(f, "one of ")?;
                 for (i, alt) in self.0.iter().enumerate() {
-                    if i > 0 { write!(f, ", ")?; }
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
                     write!(f, "`{}`", alt)?;
                 }
 

--- a/src/figment.rs
+++ b/src/figment.rs
@@ -2,10 +2,12 @@ use std::panic::Location;
 
 use serde::de::Deserialize;
 
-use crate::{Profile, Provider, Metadata};
-use crate::error::{Kind, Result};
-use crate::value::{Value, Map, Dict, Tag, ConfiguredValueDe, DefaultInterpreter, LossyInterpreter};
 use crate::coalesce::{Coalescible, Order};
+use crate::error::{Kind, Result};
+use crate::value::{
+    ConfiguredValueDe, DefaultInterpreter, Dict, LossyInterpreter, Map, Tag, Value,
+};
+use crate::{Metadata, Profile, Provider};
 
 /// Combiner of [`Provider`]s for configuration value extraction.
 ///
@@ -154,7 +156,7 @@ impl Figment {
         let tag = Tag::next();
         self.metadata.insert(tag, metadata);
         self.value = match (provider.data(), self.value) {
-            (Ok(_), e@Err(_)) => e,
+            (Ok(_), e @ Err(_)) => e,
             (Err(e), Ok(_)) => Err(e.retagged(tag)),
             (Err(e), Err(prev)) => Err(e.retagged(tag).chain(prev)),
             (Ok(mut new), Ok(old)) => {
@@ -356,7 +358,7 @@ impl Figment {
 
         let map = match map.remove(&self.profile) {
             Some(v) if self.profile.is_custom() => def.merge(v).merge(global),
-            _ => def.merge(global)
+            _ => def.merge(global),
         };
 
         Ok(Value::Dict(Tag::Default, map))
@@ -416,7 +418,8 @@ impl Figment {
     pub fn focus(&self, key: &str) -> Self {
         fn try_focus(figment: &Figment, key: &str) -> Result<Map<Profile, Dict>> {
             let map = figment.value.clone().map_err(|e| e.resolved(figment))?;
-            let new_map = map.into_iter()
+            let new_map = map
+                .into_iter()
                 .filter_map(|(k, v)| {
                     let focused = Value::Dict(Tag::Default, v).find(key)?;
                     let dict = focused.into_dict()?;
@@ -430,7 +433,7 @@ impl Figment {
         Figment {
             profile: self.profile.clone(),
             metadata: self.metadata.clone(),
-            value: try_focus(self, key)
+            value: try_focus(self, key),
         }
     }
 
@@ -482,7 +485,9 @@ impl Figment {
     /// ```
     pub fn extract<'a, T: Deserialize<'a>>(&self) -> Result<T> {
         let value = self.merged()?;
-        T::deserialize(ConfiguredValueDe::<'_, DefaultInterpreter>::from(self, &value))
+        T::deserialize(ConfiguredValueDe::<'_, DefaultInterpreter>::from(
+            self, &value,
+        ))
     }
 
     /// As [`extract`](Figment::extract_lossy), but interpret numbers and
@@ -538,7 +543,9 @@ impl Figment {
     /// ```
     pub fn extract_lossy<'a, T: Deserialize<'a>>(&self) -> Result<T> {
         let value = self.merged()?;
-        T::deserialize(ConfiguredValueDe::<'_, LossyInterpreter>::from(self, &value))
+        T::deserialize(ConfiguredValueDe::<'_, LossyInterpreter>::from(
+            self, &value,
+        ))
     }
 
     /// Deserializes the value at the `key` path in the collected value into
@@ -685,7 +692,8 @@ impl Figment {
     /// assert_eq!(profiles, &["release", "staging", "testing"]);
     /// ```
     pub fn profiles(&self) -> impl Iterator<Item = &Profile> {
-        self.value.as_ref()
+        self.value
+            .as_ref()
             .ok()
             .map(|v| v.keys())
             .into_iter()
@@ -854,9 +862,13 @@ impl Figment {
 }
 
 impl Provider for Figment {
-    fn metadata(&self) -> Metadata { Metadata::default() }
+    fn metadata(&self) -> Metadata {
+        Metadata::default()
+    }
 
-    fn data(&self) -> Result<Map<Profile, Dict>> { self.value.clone() }
+    fn data(&self) -> Result<Map<Profile, Dict>> {
+        self.value.clone()
+    }
 
     fn profile(&self) -> Option<Profile> {
         Some(self.profile.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,22 +580,24 @@
 //! [can break error attribution]:
 //! https://github.com/SergioBenitez/Figment/issues/80#issuecomment-1701946622
 
-pub mod value;
-pub mod providers;
-pub mod error;
-pub mod util;
-mod figment;
-mod profile;
 mod coalesce;
+pub mod error;
+mod figment;
 mod metadata;
+mod profile;
 mod provider;
+pub mod providers;
+pub mod util;
+pub mod value;
 
-#[cfg(any(test, feature = "test"))] mod jail;
-#[cfg(any(test, feature = "test"))] pub use jail::Jail;
+#[cfg(any(test, feature = "test"))]
+mod jail;
+#[cfg(any(test, feature = "test"))]
+pub use jail::Jail;
 
+pub use self::figment::Figment;
 #[doc(inline)]
 pub use error::{Error, Result};
-pub use self::figment::Figment;
+pub use metadata::*;
 pub use profile::Profile;
 pub use provider::*;
-pub use metadata::*;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,7 +1,7 @@
-use std::fmt;
 use std::borrow::Cow;
-use std::path::{Path, PathBuf};
+use std::fmt;
 use std::panic::Location;
+use std::path::{Path, PathBuf};
 
 use crate::Profile;
 
@@ -94,7 +94,9 @@ impl Metadata {
     /// ```
     #[inline(always)]
     pub fn from<N, S>(name: N, source: S) -> Self
-        where N: Into<Cow<'static, str>>, S: Into<Source>
+    where
+        N: Into<Cow<'static, str>>,
+        S: Into<Source>,
     {
         Metadata::named(name).source(source)
     }
@@ -112,7 +114,10 @@ impl Metadata {
     /// ```
     #[inline]
     pub fn named<T: Into<Cow<'static, str>>>(name: T) -> Self {
-        Metadata { name: name.into(), ..Metadata::default() }
+        Metadata {
+            name: name.into(),
+            ..Metadata::default()
+        }
     }
 
     /// Sets the `source` of `self` to `Some(source)`.
@@ -155,7 +160,8 @@ impl Metadata {
     /// ```
     #[inline(always)]
     pub fn interpolater<I: Clone + Send + Sync + 'static>(mut self, f: I) -> Self
-        where I: Fn(&Profile, &[&str]) -> String
+    where
+        I: Fn(&Profile, &[&str]) -> String,
     {
         self.interpolater = Box::new(f);
         self
@@ -262,7 +268,7 @@ impl Source {
     pub fn code_location(&self) -> Option<&'static Location<'static>> {
         match self {
             Source::Code(s) => Some(s),
-            _ => None
+            _ => None,
         }
     }
     /// Returns the custom source location if `self` is `Source::Custom`.
@@ -290,11 +296,11 @@ impl fmt::Display for Source {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Source::File(p) => {
-                use {std::env::current_dir, crate::util::diff_paths};
+                use {crate::util::diff_paths, std::env::current_dir};
 
                 match current_dir().ok().and_then(|cwd| diff_paths(p, cwd)) {
                     Some(r) if r.iter().count() < p.iter().count() => r.display().fmt(f),
-                    Some(_) | None => p.display().fmt(f)
+                    Some(_) | None => p.display().fmt(f),
                 }
             }
             Source::Code(l) => l.fmt(f),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -51,7 +51,7 @@ impl From<&Profile> for ProfileTag {
         match profile {
             p if p == Profile::Default => ProfileTag::Default,
             p if p == Profile::Global => ProfileTag::Global,
-            _ => ProfileTag::Custom
+            _ => ProfileTag::Custom,
         }
     }
 }
@@ -275,7 +275,8 @@ impl PartialEq<&Profile> for Profile {
 
 impl<'de> de::Deserialize<'de> for Profile {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: serde::Deserializer<'de>
+    where
+        D: serde::Deserializer<'de>,
     {
         struct Visitor;
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,5 +1,5 @@
-use crate::{Profile, Error, Metadata};
-use crate::value::{Tag, Map, Dict};
+use crate::value::{Dict, Map, Tag};
+use crate::{Error, Metadata, Profile};
 
 /// Trait implemented by configuration source providers.
 ///
@@ -98,14 +98,20 @@ pub trait Provider {
     /// This is used internally! Please, please don't use this externally. If
     /// you have a good usecase for this, let me know!
     #[doc(hidden)]
-    fn __metadata_map(&self) -> Option<Map<Tag, Metadata>> { None }
+    fn __metadata_map(&self) -> Option<Map<Tag, Metadata>> {
+        None
+    }
 }
 
 /// This is exactly `<T as Provider>`.
 impl<T: Provider> Provider for &T {
-    fn metadata(&self) -> Metadata { T::metadata(self) }
+    fn metadata(&self) -> Metadata {
+        T::metadata(self)
+    }
 
-    fn data(&self) -> Result<Map<Profile, Dict>, Error> { T::data(self) }
+    fn data(&self) -> Result<Map<Profile, Dict>, Error> {
+        T::data(self)
+    }
 
     fn profile(&self) -> Option<Profile> {
         T::profile(self)

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -3,10 +3,10 @@
 //! The [top-level docs](crate#built-in-providers) contain a list and
 //! description of each provider.
 
-mod serialized;
 mod data;
 mod env;
+mod serialized;
 
+pub use self::data::*;
 pub use self::env::Env;
 pub use self::serialized::Serialized;
-pub use self::data::*;

--- a/src/providers/serialized.rs
+++ b/src/providers/serialized.rs
@@ -2,9 +2,9 @@ use std::panic::Location;
 
 use serde::Serialize;
 
-use crate::{Profile, Provider, Metadata};
 use crate::error::{Error, Kind::InvalidType};
-use crate::value::{Value, Map, Dict};
+use crate::value::{Dict, Map, Value};
+use crate::{Metadata, Profile, Provider};
 
 /// A `Provider` that sources values directly from a serialize type.
 ///
@@ -79,7 +79,7 @@ impl<T> Serialized<T> {
             value,
             key: None,
             profile: profile.into(),
-            loc: Location::caller()
+            loc: Location::caller(),
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,9 +26,9 @@
 //!
 //! ```
 use std::fmt;
-use std::path::{Path, PathBuf, Component};
+use std::path::{Component, Path, PathBuf};
 
-use serde::de::{self, Unexpected, Deserializer};
+use serde::de::{self, Deserializer, Unexpected};
 
 /// A helper function to determine the relative path to `path` from `base`.
 ///
@@ -64,7 +64,9 @@ use serde::de::{self, Unexpected, Deserializer};
 // Copyright 2017 The Rust Project Developers.
 // Adapted from `pathdiff`, which itself adapted from rustc's path_relative_from.
 pub fn diff_paths<P, B>(path: P, base: B) -> Option<PathBuf>
-     where P: AsRef<Path>, B: AsRef<Path>
+where
+    P: AsRef<Path>,
+    B: AsRef<Path>,
 {
     let (path, base) = (path.as_ref(), base.as_ref());
     if path.has_root() != base.has_root() {
@@ -147,21 +149,21 @@ pub fn bool_from_str_or_int<'de, D: Deserializer<'de>>(de: D) -> Result<bool, D:
             match val {
                 v if uncased::eq(v, "true") => Ok(true),
                 v if uncased::eq(v, "false") => Ok(false),
-                s => Err(E::invalid_value(Unexpected::Str(s), &"true or false"))
+                s => Err(E::invalid_value(Unexpected::Str(s), &"true or false")),
             }
         }
 
         fn visit_u64<E: de::Error>(self, n: u64) -> Result<bool, E> {
             match n {
                 0 | 1 => Ok(n != 0),
-                n => Err(E::invalid_value(Unexpected::Unsigned(n), &"0 or 1"))
+                n => Err(E::invalid_value(Unexpected::Unsigned(n), &"0 or 1")),
             }
         }
 
         fn visit_i64<E: de::Error>(self, n: i64) -> Result<bool, E> {
             match n {
                 0 | 1 => Ok(n != 0),
-                n => Err(E::invalid_value(Unexpected::Signed(n), &"0 or 1"))
+                n => Err(E::invalid_value(Unexpected::Signed(n), &"0 or 1")),
             }
         }
 
@@ -198,24 +200,32 @@ pub fn bool_from_str_or_int<'de, D: Deserializer<'de>>(de: D) -> Result<bool, D:
 /// assert_eq!(pairs[2], ("value".into(), 100));
 /// ```
 pub mod vec_tuple_map {
+    use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
     use std::fmt;
-    use serde::{de, Deserialize, Serialize, Deserializer, Serializer};
 
     /// The serializer half.
     pub fn serialize<S, K, V>(vec: &[(K, V)], se: S) -> Result<S::Ok, S::Error>
-        where S: Serializer, K: Serialize, V: Serialize
+    where
+        S: Serializer,
+        K: Serialize,
+        V: Serialize,
     {
         se.collect_map(vec.iter().map(|(ref k, ref v)| (k, v)))
     }
 
     /// The deserializer half.
     pub fn deserialize<'de, K, V, D>(de: D) -> Result<Vec<(K, V)>, D::Error>
-        where D: Deserializer<'de>, K: Deserialize<'de>, V: Deserialize<'de>
+    where
+        D: Deserializer<'de>,
+        K: Deserialize<'de>,
+        V: Deserialize<'de>,
     {
         struct Visitor<K, V>(std::marker::PhantomData<Vec<(K, V)>>);
 
         impl<'de, K, V> de::Visitor<'de> for Visitor<K, V>
-            where K: Deserialize<'de>, V: Deserialize<'de>,
+        where
+            K: Deserialize<'de>,
+            V: Deserialize<'de>,
         {
             type Value = Vec<(K, V)>;
 
@@ -224,7 +234,8 @@ pub mod vec_tuple_map {
             }
 
             fn visit_map<A>(self, mut map: A) -> Result<Vec<(K, V)>, A::Error>
-                where A: de::MapAccess<'de>
+            where
+                A: de::MapAccess<'de>,
             {
                 let mut vec = Vec::with_capacity(map.size_hint().unwrap_or(0));
                 while let Some((k, v)) = map.next_entry()? {
@@ -239,7 +250,7 @@ pub mod vec_tuple_map {
     }
 }
 
-use crate::value::{Value, Dict};
+use crate::value::{Dict, Value};
 
 /// Given a key path `key` of the form `a.b.c`, creates nested dictionaries for
 /// for every path component delimited by `.` in the path string (3 in `a.b.c`),
@@ -276,7 +287,7 @@ pub fn nest(key: &str, value: Value) -> Value {
                 dict.insert(k.into(), value_from(keys, value));
                 dict.into()
             }
-            Some(_) | None => value
+            Some(_) | None => value,
         }
     }
 
@@ -321,7 +332,7 @@ macro_rules! make_cloneable {
                 Box::new(self.clone())
             }
         }
-    }
+    };
 }
 
 #[doc(hidden)]

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,16 +1,16 @@
-use std::fmt;
-use std::result;
-use std::cell::Cell;
-use std::marker::PhantomData;
 use std::borrow::Cow;
+use std::cell::Cell;
+use std::fmt;
+use std::marker::PhantomData;
+use std::result;
 
-use serde::Deserialize;
 use serde::de::{self, Deserializer, IntoDeserializer, Visitor};
-use serde::de::{SeqAccess, MapAccess, VariantAccess};
+use serde::de::{MapAccess, SeqAccess, VariantAccess};
+use serde::Deserialize;
 
-use crate::Figment;
 use crate::error::{Error, Kind, Result};
-use crate::value::{Value, Num, Empty, Dict, Tag};
+use crate::value::{Dict, Empty, Num, Tag, Value};
+use crate::Figment;
 
 pub trait Interpreter {
     fn interpret_as_bool(v: &Value) -> Cow<'_, Value> {
@@ -23,7 +23,7 @@ pub trait Interpreter {
 }
 
 pub struct DefaultInterpreter;
-impl Interpreter for DefaultInterpreter { }
+impl Interpreter for DefaultInterpreter {}
 
 pub struct LossyInterpreter;
 impl Interpreter for LossyInterpreter {
@@ -44,12 +44,17 @@ pub struct ConfiguredValueDe<'c, I = DefaultInterpreter> {
     pub config: &'c Figment,
     pub value: &'c Value,
     pub readable: Cell<bool>,
-    _phantom: PhantomData<I>
+    _phantom: PhantomData<I>,
 }
 
 impl<'c, I: Interpreter> ConfiguredValueDe<'c, I> {
     pub fn from(config: &'c Figment, value: &'c Value) -> Self {
-        Self { config, value, readable: Cell::from(true), _phantom: PhantomData }
+        Self {
+            config,
+            value,
+            readable: Cell::from(true),
+            _phantom: PhantomData,
+        }
     }
 }
 
@@ -74,7 +79,8 @@ impl<'de: 'c, 'c, I: Interpreter> Deserializer<'de> for ConfiguredValueDe<'c, I>
     type Error = Error;
 
     fn deserialize_any<V>(self, v: V) -> Result<V::Value>
-        where V: de::Visitor<'de>
+    where
+        V: de::Visitor<'de>,
     {
         let maker = |v| Self::from(self.config, v);
         let result = match *self.value {
@@ -91,12 +97,13 @@ impl<'de: 'c, 'c, I: Interpreter> Deserializer<'de> for ConfiguredValueDe<'c, I>
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         let (config, tag) = (self.config, self.value.tag());
         let result = match self.value {
             Value::Empty(_, val) => val.deserialize_any(visitor),
-            _ => visitor.visit_some(self)
+            _ => visitor.visit_some(self),
         };
 
         result.map_err(|e| e.retagged(tag).resolved(config))
@@ -106,7 +113,7 @@ impl<'de: 'c, 'c, I: Interpreter> Deserializer<'de> for ConfiguredValueDe<'c, I>
         self,
         name: &'static str,
         _fields: &'static [&'static str],
-        visitor: V
+        visitor: V,
     ) -> Result<V::Value> {
         use crate::value::magic::*;
 
@@ -116,7 +123,7 @@ impl<'de: 'c, 'c, I: Interpreter> Deserializer<'de> for ConfiguredValueDe<'c, I>
             RelativePathBuf::NAME => RelativePathBuf::deserialize_from(self, visitor),
             Tagged::<()>::NAME => Tagged::<()>::deserialize_from(self, visitor),
             // SelectedProfile::NAME => SelectedProfile::deserialize_from(self, visitor),
-            _ => self.deserialize_any(visitor)
+            _ => self.deserialize_any(visitor),
         };
 
         result.map_err(|e| e.retagged(tag).resolved(config))
@@ -142,7 +149,7 @@ impl<'de: 'c, 'c, I: Interpreter> Deserializer<'de> for ConfiguredValueDe<'c, I>
                 let tag = n.to_u32().unwrap();
                 v.visit_enum(tag.into_deserializer())
             }
-            _ => self.deserialize_any(v)
+            _ => self.deserialize_any(v),
         };
 
         result.map_err(|e| e.retagged(tag).resolved(config))
@@ -190,20 +197,28 @@ pub struct MapDe<'m, D, F: Fn(&'m Value) -> D> {
 
 impl<'m, D, F: Fn(&'m Value) -> D> MapDe<'m, D, F> {
     pub fn new(map: &'m Dict, maker: F) -> Self {
-        MapDe { iter: map.iter(), pair: None, make_deserializer: maker }
+        MapDe {
+            iter: map.iter(),
+            pair: None,
+            make_deserializer: maker,
+        }
     }
 }
 
 impl<'m, 'de, D, F> de::MapAccess<'de> for MapDe<'m, D, F>
-    where D: Deserializer<'de, Error = Error>, F: Fn(&'m Value) -> D,
+where
+    D: Deserializer<'de, Error = Error>,
+    F: Fn(&'m Value) -> D,
 {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
-        where K: de::DeserializeSeed<'de>
+    where
+        K: de::DeserializeSeed<'de>,
     {
         if let Some((k, v)) = self.iter.next() {
-            let result = seed.deserialize(k.as_str().into_deserializer())
+            let result = seed
+                .deserialize(k.as_str().into_deserializer())
                 .map_err(|e: Error| e.prefixed(k).retagged(v.tag()))
                 .map(Some);
 
@@ -215,9 +230,13 @@ impl<'m, 'de, D, F> de::MapAccess<'de> for MapDe<'m, D, F>
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
-        where V: de::DeserializeSeed<'de>
+    where
+        V: de::DeserializeSeed<'de>,
     {
-        let (key, value) = self.pair.take().expect("visit_value called before visit_key");
+        let (key, value) = self
+            .pair
+            .take()
+            .expect("visit_value called before visit_key");
         let tag = value.tag();
         seed.deserialize((self.make_deserializer)(value))
             .map_err(|e: Error| e.prefixed(key).retagged(tag))
@@ -232,17 +251,24 @@ pub struct SeqDe<'v, D, F: Fn(&'v Value) -> D> {
 
 impl<'v, D, F: Fn(&'v Value) -> D> SeqDe<'v, D, F> {
     pub fn new(seq: &'v [Value], maker: F) -> Self {
-        SeqDe { len: seq.len(), iter: seq.iter().enumerate(), make_deserializer: maker }
+        SeqDe {
+            len: seq.len(),
+            iter: seq.iter().enumerate(),
+            make_deserializer: maker,
+        }
     }
 }
 
 impl<'v, 'de, D, F> de::SeqAccess<'de> for SeqDe<'v, D, F>
-    where D: Deserializer<'de, Error = Error>, F: Fn(&'v Value) -> D,
+where
+    D: Deserializer<'de, Error = Error>,
+    F: Fn(&'v Value) -> D,
 {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
-        where T: de::DeserializeSeed<'de>
+    where
+        T: de::DeserializeSeed<'de>,
     {
         if let Some((i, item)) = self.iter.next() {
             // item.map_tag(|metadata| metadata.path.push(self.count.to_string()));
@@ -264,7 +290,8 @@ impl<'de> Deserializer<'de> for &Value {
     type Error = Error;
 
     fn deserialize_any<V>(self, v: V) -> Result<V::Value>
-        where V: de::Visitor<'de>
+    where
+        V: de::Visitor<'de>,
     {
         use Value::*;
         let result = match *self {
@@ -281,10 +308,13 @@ impl<'de> Deserializer<'de> for &Value {
     }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
-        where V: Visitor<'de>
+    where
+        V: Visitor<'de>,
     {
         if let Value::Empty(t, val) = self {
-            return val.deserialize_any(visitor).map_err(|e: Error| e.retagged(*t));
+            return val
+                .deserialize_any(visitor)
+                .map_err(|e: Error| e.retagged(*t));
         }
 
         visitor.visit_some(self)
@@ -308,7 +338,7 @@ impl<'de> Deserializer<'de> for &Value {
                 let tag = n.to_u32().unwrap();
                 v.visit_enum(tag.into_deserializer())
             }
-            _ => self.deserialize_any(v)
+            _ => self.deserialize_any(v),
         };
 
         result.map_err(|e: Error| e.retagged(self.tag()))
@@ -339,7 +369,8 @@ impl<'de> Deserializer<'de> for Num {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
-        where V: de::Visitor<'de>
+    where
+        V: de::Visitor<'de>,
     {
         match self {
             Num::U8(n) => visitor.visit_u8(n),
@@ -384,7 +415,8 @@ impl<'de> Deserializer<'de> for Empty {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
-        where V: de::Visitor<'de>
+    where
+        V: de::Visitor<'de>,
     {
         match self {
             Empty::Unit => visitor.visit_unit(),
@@ -403,18 +435,18 @@ impl<'de> Deserializer<'de> for Empty {
 impl Value {
     const NAME: &'static str = "___figment_value";
 
-    const FIELDS: &'static [&'static str] = &[
-        "___figment_value_id", "___figment_value_value"
-    ];
+    const FIELDS: &'static [&'static str] = &["___figment_value_id", "___figment_value_value"];
 
     fn deserialize_from<'de: 'c, 'c, V: de::Visitor<'de>, I: Interpreter>(
         de: ConfiguredValueDe<'c, I>,
-        visitor: V
+        visitor: V,
     ) -> Result<V::Value> {
         let mut map = Dict::new();
         map.insert(Self::FIELDS[0].into(), de.value.tag().into());
         map.insert(Self::FIELDS[1].into(), de.value.clone());
-        visitor.visit_map(MapDe::new(&map, |v| ConfiguredValueDe::<'_, I>::from(de.config, v)))
+        visitor.visit_map(MapDe::new(&map, |v| {
+            ConfiguredValueDe::<'_, I>::from(de.config, v)
+        }))
     }
 }
 
@@ -443,12 +475,12 @@ impl<'de> Deserialize<'de> for Value {
 pub struct ValueVisitor;
 
 macro_rules! visit_fn {
-    ($name:ident: $T:ty => $V:path) => (
+    ($name:ident: $T:ty => $V:path) => {
         #[inline]
         fn $name<E: de::Error>(self, v: $T) -> result::Result<Self::Value, E> {
             Ok(v.into())
         }
-    )
+    };
 }
 
 impl<'de> Visitor<'de> for ValueVisitor {
@@ -479,7 +511,8 @@ impl<'de> Visitor<'de> for ValueVisitor {
     visit_fn!(visit_f64: f64 => Num::F64);
 
     fn visit_seq<A>(self, mut seq: A) -> result::Result<Self::Value, A::Error>
-        where A: SeqAccess<'de>
+    where
+        A: SeqAccess<'de>,
     {
         let mut array: Vec<Value> = Vec::with_capacity(seq.size_hint().unwrap_or(0));
         while let Some(elem) = seq.next_element()? {
@@ -490,7 +523,8 @@ impl<'de> Visitor<'de> for ValueVisitor {
     }
 
     fn visit_map<A>(self, mut map: A) -> result::Result<Self::Value, A::Error>
-        where A: MapAccess<'de>
+    where
+        A: MapAccess<'de>,
     {
         let mut dict = Dict::new();
         let mut id: Option<Tag> = None;
@@ -500,7 +534,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
                 id = Some(map.next_value()?);
             } else if key == Value::FIELDS[1] {
                 raw_val = Some(map.next_value()?);
-            }  else {
+            } else {
                 dict.insert(key, map.next_value()?);
             }
         }
@@ -526,7 +560,8 @@ impl<'de> Visitor<'de> for ValueVisitor {
     }
 
     fn visit_some<D>(self, deserializer: D) -> result::Result<Self::Value, D::Error>
-        where D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         deserializer.deserialize_any(self)
     }

--- a/src/value/escape.rs
+++ b/src/value/escape.rs
@@ -44,13 +44,13 @@ pub fn escape(string: &str) -> Result<Cow<'_, str>, Error> {
                     Some((i, c)) => return Err(Error::InvalidEscape(i, c)),
                     None => return Err(Error::UnterminatedString(0)),
                 }
-            },
+            }
             ch if ch == '\u{09}' || ('\u{20}' <= ch && ch <= '\u{10ffff}' && ch != '\u{7f}') => {
                 // if we haven't allocated, the string contains the value
                 if let Cow::Owned(ref mut val) = output {
                     val.push(ch);
                 }
-            },
+            }
             _ => return Err(Error::InvalidCharInString(i, ch)),
         }
     }
@@ -59,7 +59,8 @@ pub fn escape(string: &str) -> Result<Cow<'_, str>, Error> {
 }
 
 fn hex<I>(mut chars: I, i: usize, len: usize) -> Result<char, Error>
-    where I: Iterator<Item = (usize, char)>
+where
+    I: Iterator<Item = (usize, char)>,
 {
     let mut buf = String::with_capacity(len);
     for _ in 0..len {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,16 +1,16 @@
 //! [`Value`] and friends: types representing valid configuration values.
 //!
-mod value;
-mod ser;
 mod de;
-mod tag;
-mod parse;
 mod escape;
+mod parse;
+mod ser;
+mod tag;
+mod value;
 
 pub mod magic;
 
-pub(crate) use {self::ser::*, self::de::*};
+pub(crate) use {self::de::*, self::ser::*};
 
 pub use tag::Tag;
-pub use value::{Value, Map, Num, Dict, Empty};
 pub use uncased::{Uncased, UncasedStr};
+pub use value::{Dict, Empty, Map, Num, Value};

--- a/src/value/tag.rs
+++ b/src/value/tag.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::sync::atomic::Ordering;
 
-use serde::{de, ser};
 use crate::profile::{Profile, ProfileTag};
+use serde::{de, ser};
 /// An opaque, unique tag identifying a value's [`Metadata`](crate::Metadata)
 /// and profile.
 ///
@@ -106,7 +106,7 @@ impl PartialEq for Tag {
     }
 }
 
-impl Eq for Tag {  }
+impl Eq for Tag {}
 
 impl Ord for Tag {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
@@ -134,7 +134,8 @@ impl From<Tag> for crate::value::Value {
 
 impl<'de> de::Deserialize<'de> for Tag {
     fn deserialize<D>(deserializer: D) -> Result<Tag, D::Error>
-        where D: de::Deserializer<'de>
+    where
+        D: de::Deserializer<'de>,
     {
         struct Visitor;
 
@@ -164,7 +165,7 @@ impl fmt::Debug for Tag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             t if t.is_default() => write!(f, "Tag::Default"),
-            _ => write!(f, "Tag({:?}, {})", self.profile_tag(), self.metadata_id())
+            _ => write!(f, "Tag({:?}, {})", self.profile_tag(), self.metadata_id()),
         }
     }
 }

--- a/src/value/value.rs
+++ b/src/value/value.rs
@@ -4,8 +4,8 @@ use std::str::{FromStr, Split};
 
 use serde::Serialize;
 
-use crate::value::{Tag, ValueSerializer, magic::Either};
-use crate::error::{Error, Actual};
+use crate::error::{Actual, Error};
+use crate::value::{magic::Either, Tag, ValueSerializer};
 
 /// An alias to the type of map used in [`Value::Dict`].
 pub type Map<K, V> = BTreeMap<K, V>;
@@ -140,7 +140,7 @@ impl Value {
         fn find(mut keys: Split<char>, value: Value) -> Option<Value> {
             match keys.next() {
                 Some(k) if !k.is_empty() => find(keys, value.into_dict()?.remove(k)?),
-                Some(_) | None => Some(value)
+                Some(_) | None => Some(value),
             }
         }
 
@@ -180,7 +180,7 @@ impl Value {
         fn find<'v>(mut keys: Split<char>, value: &'v Value) -> Option<&'v Value> {
             match keys.next() {
                 Some(k) if !k.is_empty() => find(keys, value.as_dict()?.get(k)?),
-                Some(_) | None => Some(value)
+                Some(_) | None => Some(value),
             }
         }
 
@@ -322,8 +322,8 @@ impl Value {
             Value::Num(_, num) => match num.to_u128_lossy() {
                 Some(0) => Some(false),
                 Some(1) => Some(true),
-                _ => None
-            }
+                _ => None,
+            },
             Value::String(_, s) => {
                 const TRUE: &[&str] = &["true", "yes", "1", "on"];
                 const FALSE: &[&str] = &["false", "no", "0", "off"];
@@ -335,7 +335,7 @@ impl Value {
                 } else {
                     None
                 }
-            },
+            }
             _ => None,
         }
     }
@@ -407,7 +407,8 @@ impl Value {
     }
 
     pub(crate) fn map_tag<F>(&mut self, mut f: F)
-        where F: FnMut(&mut Tag) + Copy
+    where
+        F: FnMut(&mut Tag) + Copy,
     {
         if *self.tag_mut() == Tag::Default {
             f(self.tag_mut());
@@ -472,7 +473,10 @@ impl From<&str> for Value {
 
 impl<'a, T: Into<Value> + Clone> From<&'a [T]> for Value {
     fn from(value: &'a [T]) -> Value {
-        Value::Array(Tag::Default, value.iter().map(|v| v.clone().into()).collect())
+        Value::Array(
+            Tag::Default,
+            value.iter().map(|v| v.clone().into()).collect(),
+        )
     }
 }
 
@@ -485,7 +489,8 @@ impl<T: Into<Value>> From<Vec<T>> for Value {
 
 impl<K: AsRef<str>, V: Into<Value>> From<Map<K, V>> for Value {
     fn from(map: Map<K, V>) -> Value {
-        let dict: Dict = map.into_iter()
+        let dict: Dict = map
+            .into_iter()
             .map(|(k, v)| (k.as_ref().to_string(), v.into()))
             .collect();
 
@@ -759,7 +764,7 @@ pub enum Empty {
     /// Like `Option::None`.
     None,
     /// Like `()`.
-    Unit
+    Unit,
 }
 
 impl Empty {

--- a/tests/camel-case.rs
+++ b/tests/camel-case.rs
@@ -1,11 +1,11 @@
-use figment::{Figment, providers::Env};
+use figment::{providers::Env, Figment};
 
 #[test]
 fn camel_case() {
     #[derive(serde::Deserialize, PartialEq, Debug)]
     #[serde(rename_all = "camelCase")]
     struct Config {
-        top_key_1: i32
+        top_key_1: i32,
     }
 
     figment::Jail::expect_with(|jail| {

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -1,5 +1,8 @@
+use figment::{
+    providers::{Env, Format, Json, Toml},
+    Figment,
+};
 use serde::Deserialize;
-use figment::{Figment, providers::{Format, Toml, Json, Env}};
 
 #[test]
 fn mini_cargo() {
@@ -21,12 +24,15 @@ fn mini_cargo() {
     // Replicate part of Cargo's config but also support `Cargo.json` with lower
     // precedence than `Cargo.toml`.
     figment::Jail::expect_with(|jail| {
-        jail.create_file("Cargo.toml", r#"
+        jail.create_file(
+            "Cargo.toml",
+            r#"
             [package]
             name = "test"
             authors = ["bob"]
             publish = false
-        "#)?;
+        "#,
+        )?;
 
         let config: Config = Figment::new()
             .merge(Toml::file("Cargo.toml"))
@@ -35,16 +41,19 @@ fn mini_cargo() {
             .join(Json::file("Cargo.json"))
             .extract()?;
 
-        assert_eq!(config, Config {
-            package: Package {
-                name: "test".into(),
-                description: None,
-                authors: vec!["bob".into()],
-                publish: Some(false)
-            },
-            rustc: None,
-            rustdoc: None
-        });
+        assert_eq!(
+            config,
+            Config {
+                package: Package {
+                    name: "test".into(),
+                    description: None,
+                    authors: vec!["bob".into()],
+                    publish: Some(false)
+                },
+                rustc: None,
+                rustdoc: None
+            }
+        );
 
         Ok(())
     });

--- a/tests/empty-env-vars.rs
+++ b/tests/empty-env-vars.rs
@@ -1,8 +1,8 @@
-use figment::{Figment, providers::Env};
+use figment::{providers::Env, Figment};
 
 #[derive(serde::Deserialize)]
 struct Config {
-    foo: String
+    foo: String,
 }
 
 #[test]
@@ -24,18 +24,18 @@ fn empty_env_vars() {
         assert!(config.is_err());
 
         let config = Figment::new()
-            .merge(Env::raw().map(|k| {
-                if k == "foo" { k.into() }
-                else { "".into() }
-            }))
+            .merge(Env::raw().map(|k| if k == "foo" { k.into() } else { "".into() }))
             .extract::<Config>()?;
 
         assert_eq!(config.foo, "bar");
 
         let config = Figment::new()
             .merge(Env::raw().map(|k| {
-                if k == "foo" { "   foo   ".into() }
-                else { "".into() }
+                if k == "foo" {
+                    "   foo   ".into()
+                } else {
+                    "".into()
+                }
             }))
             .extract::<Config>()?;
 

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -1,5 +1,8 @@
+use figment::{
+    providers::{Env, Format, Serialized, Toml},
+    Figment,
+};
 use serde::{Deserialize, Serialize};
-use figment::{Figment, providers::{Format, Toml, Serialized, Env}};
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Config {
@@ -11,13 +14,13 @@ pub struct Config {
 #[derive(PartialEq, Debug, Deserialize, Serialize)]
 pub enum Foo {
     Mega,
-    Supa
+    Supa,
 }
 
 #[derive(PartialEq, Debug, Deserialize, Serialize)]
 pub enum Bar {
     None,
-    Some(usize, String)
+    Some(usize, String),
 }
 
 #[derive(PartialEq, Debug, Deserialize, Serialize)]
@@ -29,14 +32,16 @@ pub enum Baz {
 
 #[test]
 fn test_enum_de() {
-    let figment = || Figment::new()
-        .merge(Serialized::defaults(Config {
-            foo: None,
-            bar: Some(Bar::Some(9999, "not-the-string".into())),
-            baz: None
-        }))
-        .merge(Toml::file("Test.toml"))
-        .merge(Env::prefixed("TEST_"));
+    let figment = || {
+        Figment::new()
+            .merge(Serialized::defaults(Config {
+                foo: None,
+                bar: Some(Bar::Some(9999, "not-the-string".into())),
+                baz: None,
+            }))
+            .merge(Toml::file("Test.toml"))
+            .merge(Env::prefixed("TEST_"))
+    };
 
     figment::Jail::expect_with(|jail| {
         let test: Config = figment().extract()?;
@@ -44,13 +49,16 @@ fn test_enum_de() {
         assert_eq!(test.bar, Some(Bar::Some(9999, "not-the-string".into())));
         assert_eq!(test.baz, None);
 
-        jail.create_file("Test.toml", r#"
+        jail.create_file(
+            "Test.toml",
+            r#"
             foo = "Mega"
             baz = "goobar"
 
             [bar]
             Some = [10, "hi"]
-        "#)?;
+        "#,
+        )?;
 
         let test: Config = figment().extract()?;
         assert_eq!(test.foo, Some(Foo::Mega));

--- a/tests/lossy_values.rs
+++ b/tests/lossy_values.rs
@@ -1,5 +1,8 @@
+use figment::{
+    providers::{Format, Toml},
+    Figment,
+};
 use serde::Deserialize;
-use figment::{Figment, providers::{Toml, Format}};
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Config {
@@ -19,10 +22,11 @@ static TOML: &str = r##"
 #[test]
 fn lossy_values() {
     let config: Config = Figment::from(Toml::string(TOML)).extract_lossy().unwrap();
-    assert_eq!(&config.u8s, &[ 1, 2, 3, 4, 5, 6 ]);
+    assert_eq!(&config.u8s, &[1, 2, 3, 4, 5, 6]);
     assert_eq!(&config.i32s, &[-1, -2, 3, -4, 5, 6]);
     assert_eq!(&config.f64s, &[1.0, 2.0, -3.0, -4.5, 5.0, -6.0]);
-    assert_eq!(&config.bs, &[
-        true, false, true, false, true, false, true, false, true, false, true, false
-    ]);
+    assert_eq!(
+        &config.bs,
+        &[true, false, true, false, true, false, true, false, true, false, true, false]
+    );
 }

--- a/tests/tagged.rs
+++ b/tests/tagged.rs
@@ -1,5 +1,8 @@
+use figment::{
+    providers::Serialized,
+    value::{magic::Tagged, Value},
+};
 use figment::{Figment, Jail, Profile};
-use figment::{value::{Value, magic::Tagged}, providers::Serialized};
 
 #[test]
 fn check_values_are_tagged_with_profile() {

--- a/tests/tuple-struct.rs
+++ b/tests/tuple-struct.rs
@@ -1,4 +1,7 @@
-use figment::{Figment, providers::{Toml, Format}};
+use figment::{
+    providers::{Format, Toml},
+    Figment,
+};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -6,13 +9,11 @@ struct Foo(pub isize);
 
 #[derive(Debug, Deserialize, PartialEq)]
 struct Config {
-    foo: Foo
+    foo: Foo,
 }
 
 #[test]
 fn one_value() {
     let config: Config = Figment::from(Toml::string("foo = 42")).extract().unwrap();
-    assert_eq!(config, Config {
-        foo: Foo(42)
-    })
+    assert_eq!(config, Config { foo: Foo(42) })
 }

--- a/tests/yaml-enum.rs
+++ b/tests/yaml-enum.rs
@@ -1,5 +1,8 @@
+use figment::{
+    providers::{Format, Yaml},
+    Figment,
+};
 use serde::Deserialize;
-use figment::{Figment, providers::{Format, Yaml}};
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]
 pub enum Trigger {


### PR DESCRIPTION
When attempting to make changes in the codebase, I noticed that the
automatic formatting on save meant that my editor was making large diffs
for small changes. This was because the code was not formatted
consistently. I ran cargo fmt to fix all this and added a CI action to
ensure that the code is always formatted correctly.

I haven't reviewed any lines from this, so there's probably things you'd have written differently manually / settings that might you may not agree with with the default rustfmt.toml, but this establishes a baseline known good that makes it possible for people to easily contribute.