### PR TITLE
Add '.rustfmt.toml' disabling formatting

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
Copied from https://github.com/rwf2/Rocket/blob/master/.rustfmt.toml

This will prevent most editors from automatically rustfmt-on-save when contributing to this project.