### PR TITLE
Reduce monomorphization in Deserializer implementation

### DIFF
--- a/src/value/magic.rs
+++ b/src/value/magic.rs
@@ -186,8 +186,7 @@ impl Magic for RelativePathBuf {
         if let Some(d) = de.value.as_dict() {
             if let Some(mpv) = d.get(Self::FIELDS[0]) {
                 if mpv.to_empty().is_none() {
-                    let map_de = MapDe::new(d, |v| ConfiguredValueDe::<I>::from(config, v));
-                    return visitor.visit_map(map_de);
+                    return visitor.visit_map(MapDe::<ConfiguredValueDe<I>>::new(d, config));
                 }
             }
         }
@@ -205,7 +204,7 @@ impl Magic for RelativePathBuf {
         // If we have this struct with no metadata_path, still use the value.
         let value = de.value.find_ref(Self::FIELDS[1]).unwrap_or(de.value);
         map.insert(Self::FIELDS[1].into(), value.clone());
-        visitor.visit_map(MapDe::new(&map, |v| ConfiguredValueDe::<I>::from(config, v)))
+        visitor.visit_map(MapDe::<ConfiguredValueDe<I>>::new(&map, config))
     }
 }
 
@@ -584,9 +583,7 @@ impl<T: for<'de> Deserialize<'de>> Magic for Tagged<T> {
         if let Some(dict) = de.value.as_dict() {
             if let Some(tagv) = dict.get(Self::FIELDS[0]) {
                 if let Ok(false) = tagv.deserialize::<Tag>().map(|t| t.is_default()) {
-                    return visitor.visit_map(MapDe::new(dict, |v| {
-                        ConfiguredValueDe::<I>::from(config, v)
-                    }));
+                    return visitor.visit_map(MapDe::<ConfiguredValueDe<I>>::new(dict, config));
                 }
             }
         }
@@ -595,7 +592,7 @@ impl<T: for<'de> Deserialize<'de>> Magic for Tagged<T> {
         let value = de.value.find_ref(Self::FIELDS[1]).unwrap_or(de.value);
         map.insert(Self::FIELDS[0].into(), de.value.tag().into());
         map.insert(Self::FIELDS[1].into(), value.clone());
-        visitor.visit_map(MapDe::new(&map, |v| ConfiguredValueDe::<I>::from(config, v)))
+        visitor.visit_map(MapDe::<ConfiguredValueDe<I>>::new(&map, config))
     }
 }
 


### PR DESCRIPTION
The `F` generic in `MapDe` and `SeqDe` makes it so that every constructed instance has its own type, which creates unnecessary monomorphizations of the underlying `Deserialize` methods. This is especially noticeable when the type being deserialized is a struct with 100+ fields that automatically derives the `Deserialize` implementation, as the multiple copies of the `visit_map` function end up being up to hundreds of KiB, bloating code size and compilation time.

Here's an example output of [`cargo-bloat`] on such a configuration:
```text
...
 0.0%   0.1%  64.2KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::magic::Tagged<()> as figment::value::magic::Magic>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#1}>>
 0.0%   0.1%  64.2KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::magic::Tagged<()> as figment::value::magic::Magic>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#2}>>
 0.0%   0.1%  64.2KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::magic::RelativePathBuf as figment::value::magic::Magic>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#2}>>
 0.0%   0.1%  64.2KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::magic::RelativePathBuf as figment::value::magic::Magic>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#0}>>
 0.0%   0.1%  64.2KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::value::Value>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#0}>>
 0.0%   0.1%  64.0KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::magic::Tagged<()> as figment::value::magic::Magic>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#1}>>
 0.0%   0.1%  64.0KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::magic::Tagged<()> as figment::value::magic::Magic>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#2}>>
 0.0%   0.1%  64.0KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::magic::RelativePathBuf as figment::value::magic::Magic>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#2}>>
 0.0%   0.1%  64.0KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::magic::RelativePathBuf as figment::value::magic::Magic>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#0}>>
 0.0%   0.1%  64.0KiB                    foundry_config <<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor as serde::de::Visitor>::visit_map::<figment::value::de::MapDe<figment::value::de::ConfiguredValueDe, <figment::value::value::Value>::deserialize_from<<foundry_config::Config as serde::de::Deserialize>::deserialize::__Visitor, figment::value::de::DefaultInterpreter>::{closure#0}>>
```

Essentially, each of `Tagged<()>`, `RelativePathBuf`, and `Value` have their own instantiation of `MapDe`, which duplicates the massive automatically-derived `serde` `visit_map` method.

[`cargo-bloat`]: https://github.com/RazrFalcon/cargo-bloat

This PR removes this `F` generic by introducing a separate trait, implemented on the deserializer `D`, that is just a simple constructor for `D`.

Another approach would be simply converting the generic `F: Fn...` to `&dyn Fn`, but this introduces some runtime overhead, so I've opted for the slightly more verbose approach.